### PR TITLE
Rendering the View 1

### DIFF
--- a/app/src/main/java/com/raywenderlich/android/creaturemon/allcreatures/AllCreaturesActivity.kt
+++ b/app/src/main/java/com/raywenderlich/android/creaturemon/allcreatures/AllCreaturesActivity.kt
@@ -32,18 +32,45 @@ package com.raywenderlich.android.creaturemon.allcreatures
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.Menu
 import android.view.MenuItem
+import android.widget.Toast
+import androidx.lifecycle.ViewModelProviders
 import com.raywenderlich.android.creaturemon.R
 import com.raywenderlich.android.creaturemon.addcreature.CreatureActivity
+import com.raywenderlich.android.creaturemon.mvibase.MviView
+import com.raywenderlich.android.creaturemon.util.CreaturemonViewModelFactory
+import com.raywenderlich.android.creaturemon.util.visible
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.PublishSubject
 import kotlinx.android.synthetic.main.activity_all_creatures.*
 import kotlinx.android.synthetic.main.content_all_creatures.*
 
-class AllCreaturesActivity : AppCompatActivity() {
+/**
+ * Make the AllCreaturesActivity an MVI view,
+ * typed by the corresponding Intent type and ViewState type.
+ */
+class AllCreaturesActivity : AppCompatActivity(),
+        MviView<AllCreaturesIntent, AllCreaturesViewState> {
 
   private val adapter = CreatureAdapter(mutableListOf())
+
+  // A PublishSubject that emits a clear all intent when a user taps clear all in the menu.
+  private val clearAllCreaturesPublisher = PublishSubject.create<AllCreaturesIntent.ClearAllCreaturesIntent>()
+
+  // Dispose of subscriptions in our activities
+  private val disposables = CompositeDisposable()
+
+  // ViewModel property
+  private val viewModel: AllCreaturesViewModel by lazy(LazyThreadSafetyMode.NONE) {
+    ViewModelProviders
+            .of(this, CreaturemonViewModelFactory.getInstance(this))
+            .get(AllCreaturesViewModel::class.java)
+  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -58,18 +85,100 @@ class AllCreaturesActivity : AppCompatActivity() {
     }
   }
 
+  override fun onStart() {
+    super.onStart()
+
+    // Bind the ViewModel
+    bind()
+  }
+
+  override fun onStop() {
+    super.onStop()
+
+    // Clear our Composite Disposable
+    disposables.clear()
+  }
+
+  /*
+   * Subscribe to the ViewModel states & tell the ViewModel to process our user intents
+   *
+   * Pass the render function into the ViewModel state subscription as an onNext handler
+   */
+  private fun bind() {
+    disposables.add(viewModel.states().subscribe(this::render))
+    viewModel.processIntents(intents())
+  }
+
   override fun onCreateOptionsMenu(menu: Menu): Boolean {
     // Inflate the menu; this adds items to the action bar if it is present.
     menuInflater.inflate(R.menu.menu_main, menu)
     return true
   }
 
+  // Publish a ClearAllCreaturesIntent when a user selects clear all in the menu
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
     return when (item.itemId) {
       R.id.action_clear_all -> {
+        clearAllCreaturesPublisher.onNext(AllCreaturesIntent.ClearAllCreaturesIntent)
         true
       }
       else -> super.onOptionsItemSelected(item)
     }
+  }
+
+  /*
+   * MVI View Functions
+   *
+   * intents() - provides the intents that the ViewModel will subscribe to.
+   * Merge the loadIntent and clearIntent observables returned by the private helper functions.
+   *
+   * render() - used to render a new state to the screen.
+   */
+  override fun intents(): Observable<AllCreaturesIntent> {
+    return Observable.merge(
+            loadIntent(),
+            clearIntent()
+    )
+  }
+
+  override fun render(state: AllCreaturesViewState) {
+
+    // Set ProgressBar visibility based on whether the state is a LoadingState
+    progressBar.visible = state.isLoading
+
+    // Handle and empty state if our creature list is empty
+    if (state.creatures.isEmpty()) {
+
+      // Otherwise update the recycler view adapter with the list if creatures in the state.
+      // Also set visibility of various views based on whether the creature list is empty
+      creaturesRecyclerView.visible = false
+      emptyState.visible
+    } else {
+      creaturesRecyclerView.visible = true
+      emptyState.visible = false
+      adapter.updateCreatures(state.creatures)
+    }
+
+    // Handle error state by showing a toasting to the user and logging the error
+    if (state.error != null) {
+      Toast.makeText(this, getString(R.string.error_loading_creatures), Toast.LENGTH_SHORT).show()
+      Log.e(TAG, "Error loading creatures: ${state.error.localizedMessage}")
+    }
+
+  }
+
+  // Function to create a Load Intent Observable
+  private fun loadIntent(): Observable<AllCreaturesIntent.LoadAllCreaturesIntent> {
+    return Observable.just(AllCreaturesIntent.LoadAllCreaturesIntent)
+  }
+
+  // Private function to return a clear all event observable
+  // which just returns the corresponding published subject.
+  private fun clearIntent(): Observable<AllCreaturesIntent.ClearAllCreaturesIntent> {
+    return clearAllCreaturesPublisher
+  }
+
+  companion object {
+    private const val TAG = "AllCreaturesActivity"
   }
 }

--- a/app/src/main/java/com/raywenderlich/android/creaturemon/app/Injection.kt
+++ b/app/src/main/java/com/raywenderlich/android/creaturemon/app/Injection.kt
@@ -1,0 +1,26 @@
+package com.raywenderlich.android.creaturemon.app
+
+import android.content.Context
+import com.raywenderlich.android.creaturemon.data.model.CreatureGenerator
+import com.raywenderlich.android.creaturemon.data.repository.CreatureRepository
+import com.raywenderlich.android.creaturemon.data.repository.room.RoomRepository
+import com.raywenderlich.android.creaturemon.util.schedulers.BaseSchedulerProvider
+import com.raywenderlich.android.creaturemon.util.schedulers.SchedulerProvider
+
+/**
+ * This is an injection object we will use to perform injection of the dependencies
+ * that our processor holders will need in their constructors.
+ */
+object Injection {
+
+    fun provideCreatureRepository(context: Context): CreatureRepository {
+        return RoomRepository()
+    }
+
+    fun provideCreatureGenerator(): CreatureGenerator {
+        return CreatureGenerator()
+    }
+
+    fun provideSchedulerProvider(): BaseSchedulerProvider = SchedulerProvider
+
+}

--- a/app/src/main/java/com/raywenderlich/android/creaturemon/util/CreaturemonViewModelFactory.kt
+++ b/app/src/main/java/com/raywenderlich/android/creaturemon/util/CreaturemonViewModelFactory.kt
@@ -1,0 +1,31 @@
+package com.raywenderlich.android.creaturemon.util
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.raywenderlich.android.creaturemon.allcreatures.AllCreaturesProcessorHolder
+import com.raywenderlich.android.creaturemon.allcreatures.AllCreaturesViewModel
+import com.raywenderlich.android.creaturemon.app.Injection
+
+/**
+ * CreaturemonViewModelFactory - used to create an AllCreaturesViewModel by passing in
+ * an AllCreaturesProcessorHolder.
+ */
+class CreaturemonViewModelFactory private constructor(
+        private val applicationContext: Context
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass == AllCreaturesViewModel::class.java) {
+            return AllCreaturesViewModel(
+                    AllCreaturesProcessorHolder(
+                            Injection.provideCreatureRepository(applicationContext),
+                            Injection.provideSchedulerProvider())) as T
+        }
+        throw IllegalAccessException("Unknown model class $modelClass")
+    }
+
+    companion object : SingletonHolderSingleArg<CreaturemonViewModelFactory, Context>
+        (::CreaturemonViewModelFactory)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
   <string name="clear_all_creatures">Clear All Creatures</string>
   <string name="add_creature">Add Creature</string>
     <string name="no_creatures_found">No creatures found.</string>
+  <string name="error_loading_creatures">Error Loading creatures.</string>
 </resources>


### PR DESCRIPTION
* AllCreaturesActivity - Add a TAG for logging in the companion object

* Make the activity an MVI view, typed by the corresponding intent type and ViewState type.

* Implement the MVIView methods

* loadIntent()  - Function to create a Load Intent Observable

* clearAllCreaturesPublisher() - A PublishSubject that emits a clear all intent when a user taps clear all in the menu.

* disposables() - A CompositeDisposable to dispose of subscriptions in our activities

* clearIntent() - private function to return a clear all event observable which just returns the corresponding published subject.

* app/Injection - Set up ViewModel in the Activity. This is an injection object we will use to perform injection of the dependencies that our processor holders will need in their constructors.

* util/CreaturemonViewModelFactory - can be used to create an AllCreaturesViewModel by passing in an AllCreaturesProcessorHolder.

* AllCreaturesActivity - Add a ViewModel property using by lazy, the ViewModelProviders class and ViewModelFactory.
  * Override onStart() - to bind the ViewModel and onStop() - to clear our Composite Disposable

* Update the onOptionsItemSelected() to publish a ClearAllCreaturesIntent when a user selects clear all in the menu